### PR TITLE
Use Java 8 for compatibility with some customers

### DIFF
--- a/build-tools-lib/build.gradle.kts
+++ b/build-tools-lib/build.gradle.kts
@@ -30,7 +30,7 @@ publishing {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(8))
     }
     withSourcesJar()
 }


### PR DESCRIPTION
I'm using mps-build-tools at a customer whose users have Java 8 installed on their machines by default and it would help me if build-tools-lib remained compatible with Java 8, given that it's only a single line of code.