### PR TITLE
Provide name of input stream to the XML parser

### DIFF
--- a/build-tools-gradle/src/main/kotlin/org/modelix/gradle/mpsbuild/MPSBuildSettings.kt
+++ b/build-tools-gradle/src/main/kotlin/org/modelix/gradle/mpsbuild/MPSBuildSettings.kt
@@ -165,7 +165,7 @@ open class MPSBuildSettings {
             description = value
         }
         fun pluginXml(content: String) {
-            pluginXml = readXmlFile(content.byteInputStream())
+            pluginXml = readXmlFile(content.byteInputStream(), "pluginXml of $implementationModule")
         }
     }
 

--- a/build-tools-lib/src/main/kotlin/org/modelix/buildtools/XmlUtils.kt
+++ b/build-tools-lib/src/main/kotlin/org/modelix/buildtools/XmlUtils.kt
@@ -103,12 +103,12 @@ fun readXmlFile(file: File): Document {
     }
 }
 
-fun readXmlFile(file: InputStream): Document {
+fun readXmlFile(file: InputStream, name: String? = null): Document {
     val dbf = DocumentBuilderFactory.newInstance()
     //dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
     disableDTD(dbf)
     val db = dbf.newDocumentBuilder()
-    return db.parse(file)
+    return db.parse(file, name)
 }
 
 private fun disableDTD(dbf: DocumentBuilderFactory) {


### PR DESCRIPTION
XML parser will include the name of the input stream (i.e. the name of the file or zip entry) in error messages, simplifying troubleshooting.