### PR TITLE
fix: idea.log caused unnecessary task invalidation

### DIFF
--- a/build-tools-lib/src/main/kotlin/org/modelix/buildtools/runner/MPSRunner.kt
+++ b/build-tools-lib/src/main/kotlin/org/modelix/buildtools/runner/MPSRunner.kt
@@ -185,13 +185,14 @@ class MPSRunner(
                     setAttribute("name", "build.dir")
                     setAttribute("location", getBuildDir().absolutePath)
                 }
+                val mpsTmpDir = getBuildDir().parentFile.resolve(getBuildDir().name + "_tmp")
                 newChild("property") {
                     setAttribute("name", "build.mps.config.path")
-                    setAttribute("location", getBuildDir().resolve("config").absolutePath)
+                    setAttribute("location", mpsTmpDir.resolve("config").absolutePath)
                 }
                 newChild("property") {
                     setAttribute("name", "build.mps.system.path")
-                    setAttribute("location", getBuildDir().resolve("system").absolutePath)
+                    setAttribute("location", mpsTmpDir.resolve("system").absolutePath)
                 }
                 newChild("property") {
                     setAttribute("name", "mps.home")


### PR DESCRIPTION
The log file created by MPS was written into the working directory which is considered an input for the runMPS task.
The path of the log directory is now outside the working directory.