### PR TITLE
Ignore empty files when collect modules

### DIFF
--- a/build-tools-lib/src/main/kotlin/org/modelix/buildtools/ModulesMiner.kt
+++ b/build-tools-lib/src/main/kotlin/org/modelix/buildtools/ModulesMiner.kt
@@ -61,6 +61,9 @@ class ModulesMiner() {
         searchedFolders.add(file)
 
         if (isIgnored(file, fileFilter)) return
+
+        if (file.length() == 0L) return
+
         if (file.isFile) {
             when (file.extension.lowercase()) {
                 // see jetbrains.mps.project.MPSExtentions


### PR DESCRIPTION
When it finds a zero-length model it throws an exception and everything breaks. Fix it to just ignore zero-length model.