### PR TITLE
fix: use an absolute path when executing ant

### DIFF
--- a/build-tools-gradle/src/main/kotlin/org/modelix/gradle/mpsbuild/MPSBuildPlugin.kt
+++ b/build-tools-gradle/src/main/kotlin/org/modelix/gradle/mpsbuild/MPSBuildPlugin.kt
@@ -41,6 +41,7 @@ import org.modelix.buildtools.ModulesMiner
 import org.modelix.buildtools.PublicationDependencyGraph
 import org.modelix.buildtools.SourceModuleOwner
 import org.modelix.buildtools.StubsSolutionGenerator
+import org.modelix.buildtools.findExecutableAbsolutePath
 import org.modelix.buildtools.invokelambda.InvokeLambda
 import org.modelix.buildtools.modelixBuildToolsVersion
 import org.modelix.buildtools.newChild
@@ -230,7 +231,7 @@ class MPSBuildPlugin @Inject constructor(val project: Project) : Plugin<Project>
 
         val taskAssembleMpsModules = project.tasks.create("assembleMpsModules", Exec::class.java) {
             workingDir(buildDir.get())
-            commandLine(antScriptFile.map { listOf("ant", "-f", it.asFile.absolutePath, "assemble") }.get())
+            commandLine(antScriptFile.map { listOf(findExecutableAbsolutePath("ant"), "-f", it.asFile.absolutePath, "assemble") }.get())
             standardOutput = System.out
             errorOutput = System.err
             standardInput = System.`in`

--- a/build-tools-lib/src/main/kotlin/org/modelix/buildtools/BuildScriptGenerator.kt
+++ b/build-tools-lib/src/main/kotlin/org/modelix/buildtools/BuildScriptGenerator.kt
@@ -47,7 +47,7 @@ class BuildScriptGenerator(
     }
 
     fun getAntPath(): String {
-        return listOf("/usr/local/bin/ant").firstOrNull { File(it).exists() } ?: "ant"
+        return findExecutableAbsolutePath("ant")
     }
 
     fun generateXML(): String {
@@ -953,3 +953,11 @@ class BuildScriptGenerator(
 }
 
 private fun getIdeaPluginsBuildDir(buildDir: File) = buildDir.resolve("idea-plugins")
+
+fun findExecutableAbsolutePath(name: String): String {
+    return System.getenv("PATH").split(File.pathSeparatorChar)
+        .map { File(it).resolve(name) }
+        .firstOrNull { it.isFile && it.exists() }
+        ?.absolutePath
+        ?: name
+}


### PR DESCRIPTION
At least with Java 21 on OSX executing an application by just specifying the name instead of the
absolute path fails with "No such file".